### PR TITLE
Fix text rendering, update dependencies for new purescript

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,18 +16,18 @@
     "output"
   ],
   "dependencies": {
-    "purescript-prelude": "^4.0.0",
+    "purescript-prelude": "^4.1.1",
     "purescript-svg-parser": "^1.0.0",
-    "purescript-record-format": "^1.0.0",
-    "purescript-optparse": "^1.0.0",
+    "purescript-record-format": "^2.0.0",
+    "purescript-optparse": "^3.0.1",
     "purescript-node-fs-aff": "^6.0.0",
     "purescript-svgo": "^0.1.0",
-    "purescript-strings-extra": "^2.0.0"
+    "purescript-strings-extra": "^2.1.0"
   },
   "devDependencies": {
     "purescript-psci-support": "^4.0.0"
   },
   "resolutions": {
-    "purescript-typelevel-prelude": "^4.0.0"
+    "purescript-typelevel-prelude": "^5.0.2"
   }
 }

--- a/src/Render.purs
+++ b/src/Render.purs
@@ -4,7 +4,6 @@ module Render
   ) where
 
 import Prelude
-
 import Data.Array as Array
 import Data.List (List)
 import Data.List as List
@@ -23,68 +22,94 @@ svgAttributeToProp :: SvgAttribute -> String
 svgAttributeToProp (SvgAttribute k v) = "attr (AttrName k) v"
 
 renderAttribute :: Int -> SvgAttribute -> String
-renderAttribute depth (SvgAttribute k v) = format (sym :: _"""attr (AttrName "{k}") "{v}"
-{s}""")
-  { k
-  , v: Regex.replace (RegexUnsafe.unsafeRegex "[\r|\n\t]+" RegexFlags.global) " " v
-  , s: String.joinWith "" $ Array.replicate depth "  "
-  }
+renderAttribute depth (SvgAttribute k v) =
+  format
+    ( sym ::
+        _
+          """attr (AttrName "{k}") "{v}"
+{s}"""
+    )
+    { k
+    , v: Regex.replace (RegexUnsafe.unsafeRegex "[\r|\n\t]+" RegexFlags.global) " " v
+    , s: String.joinWith "" $ Array.replicate depth "  "
+    }
 
 renderAttributes :: Int -> List SvgAttribute -> String
-renderAttributes depth attributes =
-  list
+renderAttributes depth attributes = list
   where
   attributes' = List.filter (\(SvgAttribute name _) -> name /= "xmlns") attributes
-  list = String.joinWith ", " $
-    Array.fromFoldable $ renderAttribute depth <$> attributes'
+
+  list =
+    String.joinWith ", "
+      $ Array.fromFoldable
+      $ renderAttribute depth
+      <$> attributes'
 
 renderSvgNode :: Int -> SvgNode -> String
 renderSvgNode depth (SvgElement element) = renderElement element depth
-renderSvgNode _ (SvgText str) = "text " <> str
+
+renderSvgNode _ (SvgText str) = "text " <> "\"\"\"" <> str <> "\"\"\""
+
 renderSvgNode _ (SvgComment str) = ""
 
 renderSvgNodes :: Int -> List SvgNode -> String
 renderSvgNodes depth nodes =
-  String.joinWith ", " $
-    Array.fromFoldable $ renderSvgNode depth <$> nodes
+  String.joinWith ", "
+    $ Array.fromFoldable
+    $ renderSvgNode depth
+    <$> nodes
 
 renderElement :: Element -> Int -> String
 renderElement { name, attributes, children } depth =
-  format (sym :: SProxy """elementNS ns (ElemName "{name}")
+  format
+    ( sym ::
+        SProxy
+          """elementNS ns (ElemName "{name}")
 {s}{attributes}
 {s}[ {children}
-{s}]""")
-  { name
-  , attributes: attributesString
-  , children: renderSvgNodes (depth + 1) children
-  , s: String.joinWith "" $ Array.replicate depth "  "
-  }
+{s}]"""
+    )
+    { name
+    , attributes: attributesString
+    , children: renderSvgNodes (depth + 1) children
+    , s: String.joinWith "" $ Array.replicate depth "  "
+    }
   where
   attributesString' = "[ " <> renderAttributes depth attributes <> "]"
-  attributesString :: String
-  attributesString = if depth == 1
-    then "( attrs <> " <> attributesString' <> ")"
-    else attributesString'
 
-type Icon =
-  { name :: String
-  , element :: Element
-  }
+  attributesString :: String
+  attributesString =
+    if depth == 1 then
+      "( attrs <> " <> attributesString' <> ")"
+    else
+      attributesString'
+
+type Icon
+  = { name :: String
+    , element :: Element
+    }
 
 renderIcon :: Icon -> String
 renderIcon { name, element } =
-  format (sym :: _"""
+  format
+    ( sym ::
+        _
+          """
 icon{name} :: forall p r i. Array (IProp r i) -> HTML p i
 icon{name} attrs =
   {element}
-""")
-  { name
-  , element: renderElement element 1
-  }
+"""
+    )
+    { name
+    , element: renderElement element 1
+    }
 
 renderIconFile :: String -> Array Icon -> String
 renderIconFile moduleName icons =
-  format (sym :: _"""module {moduleName} where
+  format
+    ( sym ::
+        _
+          """module {moduleName} where
 
 import Prelude ((<>))
 import Halogen.HTML
@@ -93,7 +118,8 @@ ns :: Namespace
 ns = Namespace "http://www.w3.org/2000/svg"
 
 {icons}
-""")
-  { moduleName
-  , icons: String.joinWith "" $ renderIcon <$> icons
-  }
+"""
+    )
+    { moduleName
+    , icons: String.joinWith "" $ renderIcon <$> icons
+    }


### PR DESCRIPTION
Tried to use this to convert Streamline icons recently and had a couple stumbling blocks. Fixed the text node rendering to wrap stuff in quotes, and updated dependencies so the project builds with latest purescript. I have `purty` installed so it looks like a lot of changes in Render.purs but the only real change is:
```
 renderSvgNode _ (SvgText str) = "text " <> "\"\"\"" <> str <> "\"\"\""
```